### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, except: [:index, :new, :create, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, except: [:index, :new, :create, :show, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -34,16 +34,18 @@ class ItemsController < ApplicationController
     end
   end
 
-  #def destroy
-    # @item = Item.find(params[:id])
-    # @item.destroy
-  #end
+  def destroy
+      if @item.destroy
+        redirect_to root_path
+      else
+        redirect_to root_path
+      end
+  end
 
   private
 
   def item_params
-    params.require(:item).permit(:image, :product, :explanation, :category_id, :condition_id, :postage_id, :prefecture_id,
-                                 :preparation_days_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :product, :explanation, :category_id, :condition_id, :postage_id, :prefecture_id, :preparation_days_id, :price).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,12 +35,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-      if @item.destroy
-        redirect_to root_path
-      else
-        redirect_to root_path
-      end
-  end
+    @item.destroy
+    redirect_to root_path
+   end
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
    <% if user_signed_in? && current_user.id == @item.user_id %> 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
    <% end %>


### PR DESCRIPTION
What
商品削除機能実装。
why
商品削除機能実装のため。

・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
　https://i.gyazo.com/ed46b35cae2a3ec8610b35316e595256.mp4